### PR TITLE
Add contact form and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SMTP_HOST=your_smtp_host
+SMTP_PORT=587
+SMTP_USER=your_username
+SMTP_PASS=your_password
+EMAIL_TO=recipient@example.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Development Instructions
+
+- Install dependencies with `npm install`.
+- Run `npm run lint` before committing.
+- Run `npm run build` to verify production readiness.
+- Use environment variables as documented in `.env.example` for the contact API.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ Can run the application in VS Code or a terminal and it will be available at `ht
 npm install
 npm run dev
 ```
+
+## Contact Feature
+
+The portfolio now includes a contact form that sends messages via email using an API route. Configure the SMTP settings by creating a `.env` file based on `.env.example`:
+
+```bash
+cp .env.example .env
+# update the values with your SMTP credentials
+```
+
+Ensure the server has network access to your mail provider. Run `npm run dev` to start the application.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import AboutSection from "@/components/AboutSection"
 import HeroSection from "@/components/HeroSection"
 import ProjectsSection from "@/components/ProjectsSection"
+import ContactSection from "@/components/ContactSection"
 export default function Home() {
   return (
     <main className="mx-auto max-w-3xl px-4 sm:px-6 md:max-w-5xl ">
       <HeroSection />
       <AboutSection />
       <ProjectsSection />
+      <ContactSection />
     </main>
   )
 }

--- a/components/ContactSection.tsx
+++ b/components/ContactSection.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react"
+
+const ContactSection = () => {
+  const [status, setStatus] = useState<string>("")
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setStatus("Sending...")
+    const formData = new FormData(e.currentTarget)
+    const response = await fetch("/api/contact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: formData.get("name"),
+        email: formData.get("email"),
+        message: formData.get("message"),
+      }),
+    })
+    if (response.ok) {
+      setStatus("Message sent!")
+      e.currentTarget.reset()
+    } else {
+      setStatus("Failed to send")
+    }
+  }
+
+  return (
+    <section id="contact" className="my-12">
+      <h1 className="text-center font-bold text-4xl">
+        Contact
+        <hr className="w-6 h-1 mx-auto my-4 bg-teal-500 border-0 rounded" />
+      </h1>
+      <form
+        onSubmit={handleSubmit}
+        className="mt-8 max-w-xl mx-auto flex flex-col space-y-4"
+      >
+        <input
+          type="text"
+          name="name"
+          required
+          placeholder="Name"
+          className="border p-2 rounded"
+        />
+        <input
+          type="email"
+          name="email"
+          required
+          placeholder="Email"
+          className="border p-2 rounded"
+        />
+        <textarea
+          name="message"
+          required
+          placeholder="Message"
+          className="border p-2 rounded"
+        />
+        <button
+          type="submit"
+          className="bg-teal-600 text-neutral-100 font-semibold px-6 py-2 rounded shadow hover:bg-teal-700"
+        >
+          Send
+        </button>
+        {status && <p className="text-center">{status}</p>}
+      </form>
+    </section>
+  )
+}
+
+export default ContactSection

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.7.1",
     "react-scroll": "^1.8.9",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "nodemailer": "^6.9.8"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.7",

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import nodemailer from 'nodemailer'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const { name, email, message } = req.body as {
+    name?: string
+    email?: string
+    message?: string
+  }
+
+  if (!name || !email || !message) {
+    return res.status(400).json({ message: 'Missing fields' })
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    })
+
+    await transporter.sendMail({
+      from: email,
+      to: process.env.EMAIL_TO,
+      subject: `Portfolio Contact from ${name}`,
+      text: message,
+    })
+
+    return res.status(200).json({ message: 'Sent' })
+  } catch (err) {
+    console.error('Mail error', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+}


### PR DESCRIPTION
## Summary
- enable users to send messages via new contact form
- implement API route using nodemailer
- document contact setup and usage
- add root development instructions

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684875856590832dbc7919ea22e581f7